### PR TITLE
Fix binja-win-doc link

### DIFF
--- a/listing.json
+++ b/listing.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "riskydissonance/matteyeux/binja-win-docs",
+    "name": "matteyeux/binja-win-docs",
     "auto_update": true
   },
   {


### PR DESCRIPTION
Hello, 

it looks like the link to the binja-win-doc plugin was wrong, it pointed to `riskydissonance/matteyeux/binja-win-docs` instead of `matteyeux/binja-win-docs` 