### PR TITLE
Fix column ordering to match header in generated README.md

### DIFF
--- a/generate_index.py
+++ b/generate_index.py
@@ -335,9 +335,9 @@ def main():
                 readme.write(f"|[{plugin['name']}]({plugin['projectUrl']})"
                     f"|[{plugin['author']}]({plugin['authorUrl']})"
                     f"|{plugin['description']}"
-                    f"|{api}"  # API type
                     f"|{datetime.fromtimestamp(plugin['lastUpdated']).date()}"
                     f"|{', '.join(sorted(plugin['type']))}"
+                    f"|{api}"  # API type
                     f"|{plugin['license']['name']}|\n")
             readme.write(info)
 


### PR DESCRIPTION
In the generated README.md, headers and content do not match up for the Last Updated, Type and API columns.

Fix by reordering the table content to match the header.

Caused-by: acea03e